### PR TITLE
Export additional signin columns

### DIFF
--- a/Get-AzureADUsersLastSignIn.ps1
+++ b/Get-AzureADUsersLastSignIn.ps1
@@ -16,10 +16,10 @@
 Important Notes:
     > Tenant should have an Azure Active Directory Premium.
     
-    > If 'Last Success Signin (UTC)' value is 'N/A', this could be due to one of the following two reasons:
+    > If 'Last Non-Interactive Signin (UTC)' / 'Last Interactive Signin (UTC)' / 'Last Success Signin (UTC)' value is 'N/A', this could be due to one of the following two reasons:
         - The last successful sign-in of a user took place before April 2020.
         - The affected user account was never used for a successful sign-in.
-        
+    > Detail Definition of the date columns can be found here: https://learn.microsoft.com/en-us/graph/api/resources/signinactivity?view=graph-rest-1.0
 #>
 
 function Connect-AzureDevicelogin {
@@ -166,7 +166,9 @@ foreach($ADUser in $AADUsers){
     if ($ADUser.accountEnabled){$ADUserepobj | Add-Member NoteProperty -Name "Account Enabled" -Value $ADUser.accountEnabled}else{$ADUserepobj | Add-Member NoteProperty -Name "Account Enabled" -Value "False"}
     if ($ADUser.onPremisesSyncEnabled){$ADUserepobj | Add-Member NoteProperty -Name "onPremisesSyncEnabled" -Value $ADUser.onPremisesSyncEnabled}else{$ADUserepobj | Add-Member NoteProperty -Name "onPremisesSyncEnabled" -Value "False"}
     $ADUserepobj | Add-Member NoteProperty -Name "Created DateTime (UTC)" -Value $ADUser.createdDateTime
-    if (($ADUser.signInActivity).lastSignInDateTime) {$ADUserepobj | Add-Member NoteProperty -Name "Last Success Signin (UTC)" -Value ($ADUser.signInActivity).lastSignInDateTime}else{$ADUserepobj | Add-Member NoteProperty -Name "Last Success Signin (UTC)" -Value "N/A"}
+	if (($ADUser.signInActivity).lastNonInteractiveSignInDateTime) {$ADUserepobj | Add-Member NoteProperty -Name "Last Non-Interactive Signin (UTC)" -Value ($ADUser.signInActivity).lastNonInteractiveSignInDateTime}else{$ADUserepobj | Add-Member NoteProperty -Name "Last Non-Interactive Signin (UTC)" -Value "N/A"}
+    if (($ADUser.signInActivity).lastSignInDateTime) {$ADUserepobj | Add-Member NoteProperty -Name "Last Interactive Signin (UTC)" -Value ($ADUser.signInActivity).lastSignInDateTime}else{$ADUserepobj | Add-Member NoteProperty -Name "Last Interactive Signin (UTC)" -Value "N/A"}
+    if (($ADUser.signInActivity).lastSuccessfulSignInDateTime) {$ADUserepobj | Add-Member NoteProperty -Name "Last Success Signin (UTC)" -Value ($ADUser.signInActivity).lastSuccessfulSignInDateTime}else{$ADUserepobj | Add-Member NoteProperty -Name "Last Success Signin (UTC)" -Value "N/A"}
     $ADUserep += $ADUserepobj
 }
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Azure AD Users Last Sign-in Report
-Coming from the fact that we have a challenge when it comes to getting last sign-in details for Azure AD users as this attribute is not available either in AzureAD or MSOnline modules, Get-AzureADUsersLastSignIn.ps1 PowerShell script resolves this challenge as it retrieves Azure AD users with their last sign in date.
+Coming from the fact that we have a challenge when it comes to getting last sign-in details for Azure AD users as this attribute is not available either in AzureAD or MSOnline modules, Get-AzureADUsersLastSignIn.ps1 PowerShell script resolves this challenge as it retrieves Azure AD users with their last sign in dates.
 
 ## Script requirements
 - You need to sign-in using a Global Admin (GA) account.
@@ -28,7 +28,8 @@ Yes, tenant should have an Azure AD Premium license.
 
 ## What data does this script retrieves?
 Get-AzureADUsersLastSignIn script retrieves the following details for each user in the tenant:  
-`Object ID, Display Name, User Principal Name, Account Enabled, onPremisesSyncEnabled, Created DateTime (UTC), Last Success Signin (UTC)`
+`Object ID, Display Name, User Principal Name, Account Enabled, onPremisesSyncEnabled, Created DateTime (UTC), Last Non-Interactive Signin (UTC), Last Interactive Signin (UTC), Last Success Signin (UTC)
+`
 
 ## Can I get users last sign-in details through Get-Azureaduser command?
 No.
@@ -36,7 +37,11 @@ No.
 ## Does this script require any PowerShell module to be installed?
 No, the script does not require any PowerShell module.
 
-## What does "N/A" value in "Last Success Signin (UTC)" field mean?
+## What does "N/A" value in "Last Success Signin (UTC)" / "Last Interactive Signin (UTC)" / "Last Success Signin (UTC)" field mean?
 If 'Last Success Signin (UTC)' value is 'N/A', this could be due to one of the following two reasons:
 - The last successful sign-in of a user took place before April 2020.
 - The affected user account was never used for a successful sign-in.
+
+
+## What is the meaning of "Last Success Signin (UTC)" / "Last Interactive Signin (UTC)" / "Last Success Signin (UTC)"?
+Detail Definition of the date columns can be found here: https://learn.microsoft.com/en-us/graph/api/resources/signinactivity?view=graph-rest-1.0


### PR DESCRIPTION
Based on the details on the page below:
https://learn.microsoft.com/en-us/graph/api/resources/signinactivity?view=graph-rest-1.0

The lastSignInDateTime field refers to "The last interactive sign-in date and time for a specific user. You can use this field to calculate the last time a user attempted (either successfully or unsuccessfully) to sign in to the directory with an interactive authentication method"

Meaning that the time stamp is updated even wtih unsuccessfully login.

The pull request make a change to export all 3 columns below
- lastNonInteractiveSignInDateTime
- lastSignInDateTime
- lastSuccessfulSignInDateTime